### PR TITLE
Move `class-validator` to peer dependency only

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@prisma/client": "^6.3.1",
         "@prisma/generator-helper": "^6.3.1",
         "@prisma/internals": "^6.3.1",
-        "class-validator": "^0.13.2",
         "pluralize": "^8.0.0",
         "prettier": "^2.8.8",
         "ts-morph": "^25.0.0",
@@ -30,7 +29,7 @@
         "typescript": "^5.4.5"
       },
       "peerDependencies": {
-        "class-validator": "^0.14.1"
+        "class-validator": "^0.14.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "@prisma/client": "^6.3.1",
     "@prisma/generator-helper": "^6.3.1",
     "@prisma/internals": "^6.3.1",
-    "class-validator": "^0.13.2",
     "pluralize": "^8.0.0",
     "prettier": "^2.8.8",
     "ts-morph": "^25.0.0",
@@ -38,7 +37,7 @@
     "typescript": "^5.4.5"
   },
   "peerDependencies": {
-    "class-validator": "^0.14.1"
+    "class-validator": "^0.14.0"
   },
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serviceup/prisma-generator-class-validator",
-  "version": "6.5.0",
+  "version": "6.6.0",
   "description": "Prisma 2+ generator to emit typescript models of your database with class validator",
   "repository": "https://github.com/ServiceUpAuto/prisma-class-validator-generator",
   "bin": {


### PR DESCRIPTION
### Description

Move `class-validator` to only a peer dependency. This ensures that there's no dependency on a version that's open to vulnerabilities.
