### PR TITLE
[SER-8593]: Improve Array Validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serviceup/prisma-generator-class-validator",
-  "version": "6.6.1",
+  "version": "6.6.2",
   "description": "Prisma 2+ generator to emit typescript models of your database with class validator",
   "repository": "https://github.com/ServiceUpAuto/prisma-class-validator-generator",
   "bin": {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -76,54 +76,94 @@ export const getTSDataTypeFromFieldType = (field: PrismaDMMF.Field) => {
 
 export const getDecoratorsByFieldType = (field: PrismaDMMF.Field) => {
   const decorators: OptionalKind<DecoratorStructure>[] = [];
+
+  if (field.isRequired) {
+    decorators.push({ name: 'IsDefined', arguments: [] });
+  } else {
+    decorators.push({ name: 'IsOptional', arguments: [] });
+  }
+
+  if (field.isList) {
+    decorators.push({ name: 'IsArray', arguments: [] });
+  }
+
+  const eachArgs: string[] = field.isList ? ['{ each: true }'] : [];
+
+  if (field.kind === 'enum') {
+    decorators.push({
+      name: 'IsIn',
+      arguments: field.isList
+        ? [`getEnumValues(${String(field.type)})`, '{ each: true }']
+        : [`getEnumValues(${String(field.type)})`],
+    });
+    return decorators;
+  }
+
+  if (field.kind === 'object') {
+    if (field.isList) {
+      decorators.push({
+        name: 'ValidateNested',
+        arguments: ['{ each: true }'],
+      });
+    }
+    return decorators;
+  }
+
   switch (field.type) {
     case 'Int':
       decorators.push({
         name: 'IsInt',
-        arguments: [],
+        arguments: eachArgs,
       });
       break;
     case 'DateTime':
       decorators.push({
         name: 'IsDate',
-        arguments: [],
+        arguments: eachArgs,
       });
       break;
     case 'String':
       decorators.push({
         name: 'IsString',
-        arguments: [],
+        arguments: eachArgs,
       });
       break;
     case 'Boolean':
       decorators.push({
         name: 'IsBoolean',
-        arguments: [],
+        arguments: eachArgs,
       });
       break;
   }
-  if (field.isRequired) {
-    decorators.unshift({
-      name: 'IsDefined',
-      arguments: [],
-    });
-  } else {
-    decorators.unshift({
-      name: 'IsOptional',
-      arguments: [],
-    });
-  }
-  if (field.kind === 'enum') {
-    decorators.push({
-      name: 'IsIn',
-      arguments: [`getEnumValues(${String(field.type)})`],
-    });
-  }
+
   return decorators;
 };
 
 export const getDecoratorsImportsByType = (field: PrismaDMMF.Field) => {
-  const validatorImports = new Set();
+  const validatorImports = new Set<string>();
+
+  if (field.isRequired) {
+    validatorImports.add('IsDefined');
+  } else {
+    validatorImports.add('IsOptional');
+  }
+
+  if (field.isList) {
+    validatorImports.add('IsArray');
+  }
+
+  if (field.kind === 'enum') {
+    validatorImports.add('IsIn');
+    return [...validatorImports];
+  }
+
+  if (field.kind === 'object') {
+    if (field.isList) {
+      validatorImports.add('ValidateNested');
+    }
+    return [...validatorImports];
+  }
+
   switch (field.type) {
     case 'Int':
       validatorImports.add('IsInt');
@@ -138,14 +178,7 @@ export const getDecoratorsImportsByType = (field: PrismaDMMF.Field) => {
       validatorImports.add('IsBoolean');
       break;
   }
-  if (field.isRequired) {
-    validatorImports.add('IsDefined');
-  } else {
-    validatorImports.add('IsOptional');
-  }
-  if (field.kind === 'enum') {
-    validatorImports.add('IsIn');
-  }
+
   return [...validatorImports];
 };
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -142,41 +142,37 @@ export const getDecoratorsByFieldType = (field: PrismaDMMF.Field) => {
 export const getDecoratorsImportsByType = (field: PrismaDMMF.Field) => {
   const validatorImports = new Set<string>();
 
-  if (field.isRequired) {
-    validatorImports.add('IsDefined');
+  if (field.kind === 'enum') {
+    validatorImports.add('IsIn');
+  } else if (field.kind === 'object') {
+    if (field.isList) {
+      validatorImports.add('ValidateNested');
+    }
   } else {
-    validatorImports.add('IsOptional');
+    switch (field.type) {
+      case 'Int':
+        validatorImports.add('IsInt');
+        break;
+      case 'DateTime':
+        validatorImports.add('IsDate');
+        break;
+      case 'String':
+        validatorImports.add('IsString');
+        break;
+      case 'Boolean':
+        validatorImports.add('IsBoolean');
+        break;
+    }
   }
 
   if (field.isList) {
     validatorImports.add('IsArray');
   }
 
-  if (field.kind === 'enum') {
-    validatorImports.add('IsIn');
-    return [...validatorImports];
-  }
-
-  if (field.kind === 'object') {
-    if (field.isList) {
-      validatorImports.add('ValidateNested');
-    }
-    return [...validatorImports];
-  }
-
-  switch (field.type) {
-    case 'Int':
-      validatorImports.add('IsInt');
-      break;
-    case 'DateTime':
-      validatorImports.add('IsDate');
-      break;
-    case 'String':
-      validatorImports.add('IsString');
-      break;
-    case 'Boolean':
-      validatorImports.add('IsBoolean');
-      break;
+  if (field.isRequired) {
+    validatorImports.add('IsDefined');
+  } else {
+    validatorImports.add('IsOptional');
   }
 
   return [...validatorImports];

--- a/test/unit/helpers.test.ts
+++ b/test/unit/helpers.test.ts
@@ -122,6 +122,60 @@ describe('helpers', () => {
       expect(decorators).toContainEqual({ name: 'IsOptional', arguments: [] });
       expect(decorators).toContainEqual({ name: 'IsString', arguments: [] });
     });
+
+    test('uses IsArray and each option for scalar list fields', () => {
+      const field = {
+        name: 'allowedServiceTypes',
+        kind: 'scalar',
+        type: 'String',
+        isRequired: true,
+        isList: true,
+      } as DMMF.Field;
+
+      const decorators = getDecoratorsByFieldType(field);
+      expect(decorators).toEqual([
+        { name: 'IsDefined', arguments: [] },
+        { name: 'IsArray', arguments: [] },
+        { name: 'IsString', arguments: ['{ each: true }'] },
+      ]);
+    });
+
+    test('uses ValidateNested for relation list fields', () => {
+      const field = {
+        name: 'posts',
+        kind: 'object',
+        type: 'Post',
+        isRequired: true,
+        isList: true,
+      } as DMMF.Field;
+
+      const decorators = getDecoratorsByFieldType(field);
+      expect(decorators).toEqual([
+        { name: 'IsDefined', arguments: [] },
+        { name: 'IsArray', arguments: [] },
+        { name: 'ValidateNested', arguments: ['{ each: true }'] },
+      ]);
+    });
+
+    test('uses IsIn with each option for enum list fields', () => {
+      const field = {
+        name: 'labels',
+        kind: 'enum',
+        type: 'Role',
+        isRequired: true,
+        isList: true,
+      } as DMMF.Field;
+
+      const decorators = getDecoratorsByFieldType(field);
+      expect(decorators).toEqual([
+        { name: 'IsDefined', arguments: [] },
+        { name: 'IsArray', arguments: [] },
+        {
+          name: 'IsIn',
+          arguments: ['getEnumValues(Role)', '{ each: true }'],
+        },
+      ]);
+    });
   });
 
   describe('getDecoratorsImportsByType', () => {
@@ -167,6 +221,21 @@ describe('helpers', () => {
       const imports = getDecoratorsImportsByType(field);
       
       expect(imports).toContain('IsIn');
+      expect(imports).toContain('IsDefined');
+    });
+
+    test('returns IsArray and ValidateNested for relation lists', () => {
+      const field = {
+        name: 'posts',
+        kind: 'object',
+        type: 'Post',
+        isRequired: true,
+        isList: true,
+      } as DMMF.Field;
+
+      const imports = getDecoratorsImportsByType(field);
+      expect(imports).toContain('IsArray');
+      expect(imports).toContain('ValidateNested');
       expect(imports).toContain('IsDefined');
     });
   });


### PR DESCRIPTION
### Description
- Improvements to the validation decorators added to array types. Previously array types were being created with the primitive validation only so a string array would only get the `@IsString` decorator instead of the proper 
```
@IsArray
@IsString({ each: true })
```

<img width="1214" height="587" alt="image" src="https://github.com/user-attachments/assets/455e3066-ff99-42d4-b32a-9b9a738f9072" />

For nested types, we are now validating using the `@ValidateNested` decorator:

<img width="1212" height="827" alt="image" src="https://github.com/user-attachments/assets/79ad73e1-045a-441d-8ee5-3b8e774a7eff" />