### PR TITLE
Fix: De-Dupe Enum Imports (bump to 6.6.3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serviceup/prisma-generator-class-validator",
-  "version": "6.6.2",
+  "version": "6.6.3",
   "description": "Prisma 2+ generator to emit typescript models of your database with class validator",
   "repository": "https://github.com/ServiceUpAuto/prisma-class-validator-generator",
   "bin": {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -219,9 +219,13 @@ export const generateEnumImports = (
   sourceFile: SourceFile,
   fields: PrismaDMMF.Field[],
 ) => {
-  const enumsToImport = fields
-    .filter((field) => field.kind === 'enum')
-    .map((field) => field.type);
+  const enumsToImport = Array.from(
+    new Set(
+      fields
+        .filter((field) => field.kind === 'enum')
+        .map((field) => field.type),
+    ),
+  );
 
   if (enumsToImport.length > 0) {
     sourceFile.addImportDeclaration({

--- a/test/unit/helpers.test.ts
+++ b/test/unit/helpers.test.ts
@@ -1,9 +1,11 @@
-import { 
+import {
   getTSDataTypeFromFieldType,
   getDecoratorsByFieldType,
-  getDecoratorsImportsByType
+  getDecoratorsImportsByType,
+  generateEnumImports
 } from '../../src/helpers';
 import { DMMF } from '@prisma/generator-helper';
+import { Project } from 'ts-morph';
 
 describe('helpers', () => {
   describe('getTSDataTypeFromFieldType', () => {
@@ -237,6 +239,91 @@ describe('helpers', () => {
       expect(imports).toContain('IsArray');
       expect(imports).toContain('ValidateNested');
       expect(imports).toContain('IsDefined');
+    });
+  });
+
+  describe('generateEnumImports', () => {
+    const makeSourceFile = () => {
+      const project = new Project({ useInMemoryFileSystem: true });
+      return project.createSourceFile('model.ts', '');
+    };
+
+    test('emits unique enum imports when multiple fields share an enum type', () => {
+      const fields = [
+        {
+          name: 'previousStatus',
+          type: 'ServiceApprovalStatus',
+          kind: 'enum',
+          isRequired: false,
+          isList: false,
+        },
+        {
+          name: 'newStatus',
+          type: 'ServiceApprovalStatus',
+          kind: 'enum',
+          isRequired: true,
+          isList: false,
+        },
+        {
+          name: 'changeReason',
+          type: 'ApprovalChangeReason',
+          kind: 'enum',
+          isRequired: true,
+          isList: false,
+        },
+      ] as unknown as DMMF.Field[];
+
+      const sourceFile = makeSourceFile();
+      generateEnumImports(sourceFile, fields);
+
+      const [decl] = sourceFile.getImportDeclarations();
+      const names = decl.getNamedImports().map((n) => n.getName());
+
+      expect(decl.getModuleSpecifierValue()).toBe('../enums');
+      expect(names).toEqual(['ServiceApprovalStatus', 'ApprovalChangeReason']);
+    });
+
+    test('emits distinct enum imports when each field has a different enum type', () => {
+      const fields = [
+        {
+          name: 'status',
+          type: 'InvoiceStatus',
+          kind: 'enum',
+          isRequired: true,
+          isList: false,
+        },
+        {
+          name: 'rpType',
+          type: 'ResponsiblePartyType',
+          kind: 'enum',
+          isRequired: true,
+          isList: false,
+        },
+      ] as unknown as DMMF.Field[];
+
+      const sourceFile = makeSourceFile();
+      generateEnumImports(sourceFile, fields);
+
+      const [decl] = sourceFile.getImportDeclarations();
+      const names = decl.getNamedImports().map((n) => n.getName());
+      expect(names).toEqual(['InvoiceStatus', 'ResponsiblePartyType']);
+    });
+
+    test('skips the import declaration entirely when no fields are enums', () => {
+      const fields = [
+        {
+          name: 'id',
+          type: 'Int',
+          kind: 'scalar',
+          isRequired: true,
+          isList: false,
+        },
+      ] as unknown as DMMF.Field[];
+
+      const sourceFile = makeSourceFile();
+      generateEnumImports(sourceFile, fields);
+
+      expect(sourceFile.getImportDeclarations()).toHaveLength(0);
     });
   });
 });


### PR DESCRIPTION
This PR fixes an issue with duplicate imports.

`generateEnumImports` maps every enum field to its type name and passes the resulting list straight to `sourceFile.addImportDeclaration`. When two or more fields on a model reference the same enum type, the generated model file contains duplicate named imports:

Given the following model:

```prisma
model ServiceApprovalHistory {
  previousStatus ServiceApprovalStatus?
  newStatus      ServiceApprovalStatus
}
```

It generates:

```ts
import { ServiceApprovalStatus, ServiceApprovalStatus, ApprovalChangeReason } from "../enums";
//                              ^^^^^^^^^^^^^^^^^^^^^^ TS2300: Duplicate identifier
```

This fails TypeScript compilation for any downstream consumer that imports the generated model.