### PR TITLE
Tidy package.sh

### DIFF
--- a/package.sh
+++ b/package.sh
@@ -1,10 +1,9 @@
 #!/bin/bash
+set -euo pipefail
 START_TIME=$SECONDS
 
-echo "Buidling package..."
-rm -r lib
-tsc
-rm -r package
+echo "Building package..."
+rm -rf lib package
 mkdir package
 
 npm run build
@@ -12,9 +11,6 @@ npm run build
 echo "Copying files..."
 cp -r lib package/lib
 cp package.json README.md LICENSE package
-
-echo "Making package.json public..."
-sed -i 's/"private": true/"private": false/' ./package/package.json
 
 ELAPSED_TIME=$(($SECONDS - $START_TIME))
 echo "Done in $ELAPSED_TIME seconds!"


### PR DESCRIPTION
## Summary
`npm run package:publish` was breaking on macOS at the `sed -i 's/.../.../'` line because BSD sed (macOS) expects `-i ''` while GNU sed (Linux) doesn't. The substitution it was attempting was a no-op anyway — `package.json` doesn't contain `\"private\": true`, so there's nothing to flip. Drop it.

## Changes
- Remove the dead `sed -i 's/\"private\": true/\"private\": false/' ./package/package.json` line.
- Collapse `rm -r lib && rm -r package` into one `rm -rf lib package`.
- Drop the bare `tsc` call — `npm run build` immediately below is `tsc -p tsconfig.build.json`. The bare one was duplicate work that wrote to a slightly different output and then got clobbered.
- `set -euo pipefail` so a future regression doesn't silently succeed past a failed step.
- Fix `Buidling` → `Building`.

## Testing
- [x] `bash package.sh` runs clean on macOS; `package/` ends up with `lib/`, `LICENSE`, `package.json`, `README.md` as before.

## Notes for Reviewer
N/A